### PR TITLE
Changed type of Picture to Hyperlink

### DIFF
--- a/view-samples/contact-card-format/README.md
+++ b/view-samples/contact-card-format/README.md
@@ -39,7 +39,7 @@ All fields below should be part of the view, but only those marked with Required
 |Single line of text|City||
 |Single line of text|State||
 |Single line of text|ZipCode||
-|Picture|Picture||
+|Hyperlink|Picture||
 |Multiple lines of text|Notes||
 
 ## Sample


### PR DESCRIPTION
There's a new column type called Image that's easily confused with Picture. I think "Hyperlink or Picture" was renamed to just "Hyperlink" when "Image" was added.

| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New sample?      | no 

#### What's in this Pull Request?

One word change to the README.md