### PR TITLE
Changed Picture to Hyperlink

### DIFF
--- a/view-samples/birthday-format/README.md
+++ b/view-samples/birthday-format/README.md
@@ -21,7 +21,7 @@ This is a sample derived from the [contact card row format](../contact-card-form
 |Single line of text|Email||
 |Date Time|Birthday|Yes|
 |Calculated Column|BirthMonthDay||
-|Picture|Picture||
+|Hyperlink|Picture||
 
 You need the BirthMonthDay Calculated Column so that it only shows the current month name spelled out and date, not the year. The formula for this calculated column is below:
 


### PR DESCRIPTION
The Picture column type is misleading. The column type's name that worked for me is Hyperlink. It was renamed to just Hyperlink from the classic name for "Hyperlink or Picture" column type.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New sample?      | no 

#### What's in this Pull Request?

One word change to the README.md