### PR TITLE
Added row 119: white-space: nowrap

### DIFF
--- a/view-samples/project-gantt-chart/project-gantt-chart.json
+++ b/view-samples/project-gantt-chart/project-gantt-chart.json
@@ -115,7 +115,8 @@
               "outline": "none",
               "display": "inline-block",
               "overflow": "hidden",
-              "text-overflow": "ellipsis"
+              "text-overflow": "ellipsis",
+              "white-space": "nowrap"
             },
             "attributes": {
               "title": "[$Title]",


### PR DESCRIPTION
Small modification to enable proper behavior of the "text-overflow": "ellipsis" of the left hand title.
Thanks @Fungopus for report.

| Q               | A
| --------------- | ---
| Bug fix?        |  yes
| New sample?      | no
| Related issues?  | #386

#### What's in this Pull Request?
Added the "text-overflow": "ellipsis" to enable proper behavior of left hand title when title would exceed the allocated space