### PR TITLE
tools: customizer export and import 

### DIFF
--- a/tools/formatter-exportimport/Apply-SPOListFormatting.ps1
+++ b/tools/formatter-exportimport/Apply-SPOListFormatting.ps1
@@ -1,0 +1,159 @@
+
+[CmdletBinding()]
+param(
+    $tenantName,
+    $siteName,
+    [Parameter(Mandatory = $True, ParameterSetName = "Certificate")]
+    $appId,
+    [Parameter(Mandatory = $True, ParameterSetName = "Certificate")]
+    $secureFilePath,
+    [Parameter(Mandatory = $True, ParameterSetName = "Certificate")]
+    [Security.SecureString] $pfxPassword,
+    [Parameter(Mandatory = $True, ParameterSetName = "Certificate")]
+    $tenantId,
+    [Parameter(Mandatory = $True, ParameterSetName = "User")]
+    $userName,
+    [Parameter(Mandatory = $True, ParameterSetName = "User")]
+    [Security.SecureString] $userPassword,
+    $folderPath
+)
+
+function Set-ListFormatting {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string]
+        $listName,
+        [string]
+        $folderPath
+    )
+    if (Test-Path -Path $folderPath){
+
+        Write-Host "LIST $listName "
+        $clientContext = Get-PnPContext
+        $list = Get-PnPList $listName
+
+        #Get Content Type
+        $contentType = Get-PnPContentType -List $listName | Where-Object { $_.Name -eq "Item" -or $_.Name -eq "Element" }
+        $clientContext.Load($contentType)
+        $clientContext.Load($contentType.FieldLinks)
+        $clientContext.ExecuteQuery()
+
+        # 1. Set form customizers
+        if ($t=Test-Path -Path "$folderPath\ListFormatting.Form.$listName.json" -PathType leaf){
+            Write-Host "Setting form customizers from $folderPath\ListFormatting.Form.$listName.json"
+            $contentType.ClientFormCustomFormatter = (Get-Content -Raw -Path "$folderPath\ListFormatting.Form.$listName.json").ToString()
+        }
+        # 2.a Set fieldLinks order
+        if ($t=Test-Path -Path "$folderPath\ListFormatting.ColumnOrder.$listName.csv" -PathType leaf) {
+            Write-Host "Setting fields order from $folderPath\ListFormatting.ColumnOrder.$listName.csv"
+
+            $ColumnOrder = (Import-Csv "$folderPath\ListFormatting.ColumnOrder.$listName.csv").Name
+            $contentType.FieldLinks.Reorder($ColumnOrder)
+        }
+        # 2.b Set fieldLinks.Hidden 
+        if ($t = Test-Path -Path "$folderPath\ListFormatting.ColumnOrder.$listName.csv" -PathType leaf) {
+            Write-Host "Setting hidden fields from $folderPath\ListFormatting.ColumnOrder.$listName.csv"
+            
+            Import-Csv "$folderPath\ListFormatting.ColumnOrder.$listName.csv" | ForEach-Object{
+                $contentType.FieldLinks.GetById($_.Id).Hidden = [System.Convert]::ToBoolean($_.Hidden)
+            }
+        }
+        $contentType.Update(0)
+        $clientContext.ExecuteQuery()
+
+        # 3. Set list views
+        if ($t = Test-Path -Path  "$folderPath\List.Views.$listName.csv" -PathType leaf) {
+            Write-Host "Setting views"
+            
+            #Get All List Views 
+            $clientContext.Load($list.Views)
+            $clientContext.ExecuteQuery()
+            $listUrl=$list.RootFolder.ServerRelativeUrl+"/"
+            $views = $list.Views | Select-Object Title, @{name = "Url"; expression = { $_.ServerRelativeUrl.Replace($listUrl, "").Replace(".aspx", "")}}
+
+            Import-Csv "$folderPath\List.Views.$listName.csv" | ForEach-Object {
+
+                $xml = [xml]( Get-Content "$folderPath\List.View.$listName.$($_.Id).xml" -Raw)
+                $isDefault = [boolean]$xml.View.DefaultView
+                $fields =  $xml.View.ViewFields.FieldRef.Name 
+                $query = $xml.View.Query.InnerXml
+                $aggregations = $xml.View.Aggregations.InnerXml
+                $viewType2 = $xml.View.ViewType2
+
+                $url = $_.Url
+                $viewTitle = ($views | Where-Object { $_.Url -eq $url } ).Title
+
+                if($null -ne $viewTitle){
+                    Write-Host "Updating view $viewTitle to $($_.Title)"
+                    $v = Set-PnPView -List $listName -Identity $viewTitle -Fields $fields -Values @{Title = $_.Title; ViewQuery = $query; ViewType2 = $viewType2 } -Aggregations $aggregations
+                }
+                else{
+                    Write-Host "Creating view $($_.Title)"
+                    #cannot set view url when creating the list. the following workaroud required
+                    $v = Add-PnPView -List $listName -Title $_.Url  -SetAsDefault:$isDefault -Fields $fields -Query $query -Aggregations $aggregations
+                    $v = Set-PnPView -List $listName -Identity $_.Url -Values @{Title = $_.Title ; ViewType2 = $viewType2} 
+                }
+            }
+        }
+
+        #Set list views formatting
+        if ($t=Test-Path -Path "$folderPath\ListFormatting.Views.$listName.csv" -PathType leaf){
+            Write-Host "Setting  list views formatting"
+
+            #Get All List Views 
+            $clientContext.Load($list.Views)
+            $clientContext.ExecuteQuery()
+            $views = $list.Views.Title
+
+            #Get exported Views Info (Title & Id)
+            Import-Csv "$folderPath\ListFormatting.Views.$listName.csv" | ForEach-Object{
+                #If target list contains the view and the file exists
+                if ($views.Contains($_.Title) ) {
+                    # Update the List View Formatting Definition
+                    $listViewFormattingJSON = Get-Content -Raw -Path "$folderPath\ListFormatting.View.$listName.$($_.Id).json";
+                    $listViewColumnDefinition = Get-PnPView -List $listName -Identity $_.Title  
+                    $listViewColumnDefinition | Set-PnPView -Values  @{CustomFormatter = $listViewFormattingJSON.ToString() }
+                }
+            }
+        }
+        #Set columns formatting
+        if ($t=Test-Path -Path "$folderPath\ListFormatting.Columns.$listName.csv" -PathType leaf) {
+            Write-Host "Setting columns formatting"
+
+            #Get All List Columns
+            $clientContext.Load($list.Fields)
+            $clientContext.ExecuteQuery()
+            $columns = $list.Fields.InternalName
+
+            Import-Csv "$folderPath\ListFormatting.Columns.$listName.csv"  | ForEach-Object { #$columns.Contains($_.InternalName)
+                if ($columns.Contains($_.InternalName)){
+                    Write-Host "Setting formatter for $($_.InternalName)"
+                    $ColumnFormattingJSON = Get-Content -Raw -Path "$folderPath\ListFormatting.Column.$listName.$($_.InternalName).json";
+                    $listColumnDefinition = Get-PnPField -List $listName -Identity $_.InternalName
+                    $listColumnDefinition | Set-PnPField -Values @{CustomFormatter = $ColumnFormattingJSON.ToString() }
+                }
+            }
+        }
+        
+    }
+}
+
+$siteUrl = "https://$tenantName.sharepoint.com/sites/$siteName"
+Install-Module PnP.PowerShell -Scope "CurrentUser" -Verbose -AllowClobber -Force
+
+switch ($PSCmdlet.ParameterSetName) {
+    "Certificate" {  
+        Connect-PnPOnline -ClientId $appId -CertificatePath $secureFilePath -CertificatePassword $pfxPassword -Url $siteUrl -Tenant $tenantId
+        Write-Host "Signed in to $siteUrl"
+    }
+    "User" {  
+        [System.Management.Automation.PSCredential]$PSCredentials = New-Object System.Management.Automation.PSCredential($userName, $userPassword)
+        Connect-PnPOnline -Credentials $PSCredentials -Url $siteUrl 
+        Write-Host "Signed in to $siteUrl"
+    }
+}
+
+# Example use
+Set-ListFormatting -folderPath $folderPath -listName "List1"
+Set-ListFormatting -folderPath $folderPath -listName "List2"

--- a/tools/formatter-exportimport/Export-SPOListFormatting.ps1
+++ b/tools/formatter-exportimport/Export-SPOListFormatting.ps1
@@ -1,0 +1,105 @@
+
+[CmdletBinding()]
+param(
+    $tenantName,
+    $siteName,
+    [Parameter(Mandatory = $True, ParameterSetName = "Certificate")]
+    $appId,
+    [Parameter(Mandatory = $True, ParameterSetName = "Certificate")]
+    $secureFilePath,
+    [Parameter(Mandatory = $True, ParameterSetName = "Certificate")]
+    [Security.SecureString] $pfxPassword,
+    [Parameter(Mandatory = $True, ParameterSetName = "Certificate")]
+    $tenantId,
+    [Parameter(Mandatory = $True, ParameterSetName = "User")]
+    $userName,
+    [Parameter(Mandatory = $True, ParameterSetName = "User")]
+    [Security.SecureString] $userPassword,
+    $folderPath)
+
+
+function Export-ListFormatting {
+    [CmdletBinding()]
+    param (
+        [Parameter()]
+        [string]
+        $listName,
+        [string]
+        $folderPath
+    )
+
+    $clientContext = Get-PnPContext
+    $list = Get-PnPList $listName -Includes SchemaXml
+
+    #Get Content Type
+    $contentTypes = $list.ContentTypes
+    $clientContext.Load($contentTypes)
+    $clientContext.ExecuteQuery()    
+    $ct = $ContentTypes[0]
+
+    #Get Field links
+    $fieldLinks = $ct.FieldLinks
+    $clientContext.Load($fieldLinks)
+    $clientContext.ExecuteQuery()
+
+    #Get All List Views of the List
+    $clientContext.Load($list.Views)
+    $clientContext.ExecuteQuery()
+    
+    # 1. Get form customizer
+    $ct.ClientFormCustomFormatter | Out-File "$folderPath\ListFormatting.Form.$listName.json"
+    # 2.Get fieldLinks settings
+    $ct.FieldLinks | Select-Object Name, Hidden, Id |  Export-Csv  "$folderPath\ListFormatting.ColumnOrder.$listName.csv" -NoTypeInformation
+
+    # 3. Get list views 
+    $listUrl=$list.RootFolder.ServerRelativeUrl+"/"
+    $list.Views | Where-Object { $_.PersonalView -eq $false } | Select-Object Title, Id, @{name = "Url"; expression = { $_.ServerRelativeUrl.Replace($listUrl,"").Replace(".aspx","") } } | Export-Csv  "$folderPath\List.Views.$listName.csv" -NoTypeInformation
+    $list.Views | ForEach-Object {
+        $v = Get-PnPView -List $list -Identity $_.Id -Includes HtmlSchemaXml 
+        $v.HtmlSchemaXml |  Out-File "$folderPath\List.View.$listName.$($_.Id).xml"
+    }
+
+    #get list views formatting
+    $views = $list.Views | Where-Object { $null -ne $_.CustomFormatter } 
+    if($null -ne $views){
+        $views | Select-Object Title, Id | Export-Csv  "$folderPath\ListFormatting.Views.$listName.csv" -NoTypeInformation
+        $views | ForEach-Object {
+            $_.CustomFormatter | Out-File "$folderPath\ListFormatting.View.$listName.$($_.Id).json"
+        }
+    }
+
+    #get columns formatting
+    $columns= Get-PnPField -List $listName | Where-Object {$null -ne $_.CustomFormatter } 
+    if($null -ne $columns){
+        $columns | Select-Object InternalName | Export-Csv   "$folderPath\ListFormatting.Columns.$listName.csv" -NoTypeInformation
+        $columns | ForEach-Object {
+            $_.CustomFormatter | Out-File "$folderPath\ListFormatting.Column.$listName.$($_.InternalName).json"
+        }
+    }
+}
+    
+$siteUrl = "https://$tenantName.sharepoint.com/sites/$siteName"
+Write-Host $siteUrl
+Install-Module PnP.PowerShell -Scope "CurrentUser" -Verbose -AllowClobber -Force
+
+switch ($PSCmdlet.ParameterSetName) {
+    "Certificate" {  
+        Connect-PnPOnline -ClientId $appId -CertificatePath $secureFilePath -CertificatePassword $pfxPassword -Url $siteUrl -Tenant $tenantId
+        Write-Host "Signed in to $siteUrl"
+    }
+    "User" {  
+        [System.Management.Automation.PSCredential]$PSCredentials = New-Object System.Management.Automation.PSCredential($userName, $userPassword)
+        Connect-PnPOnline -Credentials $PSCredentials -Url $siteUrl 
+        Write-Host "Signed in to $siteUrl"
+    }
+}
+#Recreate target folder
+if (Test-Path -Path $folderPath){
+    Remove-Item -LiteralPath $folderPath -Recurse
+}
+New-Item -ItemType Directory -Force -Path $folderPath
+
+# Example use
+Export-ListFormatting -folderPath $folderPath -listName "List1"
+Export-ListFormatting -folderPath $folderPath -listName "List2"
+

--- a/tools/formatter-exportimport/Export-SPOListFormatting.ps1
+++ b/tools/formatter-exportimport/Export-SPOListFormatting.ps1
@@ -31,19 +31,10 @@ function Export-ListFormatting {
     $clientContext = Get-PnPContext
     $list = Get-PnPList $listName -Includes SchemaXml
 
-    #Get Content Type
-    $contentTypes = $list.ContentTypes
-    $clientContext.Load($contentTypes)
-    $clientContext.ExecuteQuery()    
-    $ct = $ContentTypes[0]
-
-    #Get Field links
-    $fieldLinks = $ct.FieldLinks
-    $clientContext.Load($fieldLinks)
-    $clientContext.ExecuteQuery()
-
-    #Get All List Views of the List
+    $contentType = Get-PnPContentType -List $listName | Where-Object { $_.Name -eq "Item" -or $_.Name -eq "Element" }
     $clientContext.Load($list.Views)
+    $clientContext.Load($contentType)
+    $clientContext.Load($contentType.FieldLinks)
     $clientContext.ExecuteQuery()
     
     # 1. Get form customizer

--- a/tools/formatter-exportimport/README.md
+++ b/tools/formatter-exportimport/README.md
@@ -52,7 +52,7 @@ steps:
     git push  origin HEAD:$(Build.SourceBranch)
     displayName: Commit generated files to repo
 ```
-### Example export pipeline
+### Example import pipeline
 ```
 # vmImage: 'ubuntu-latest'
 steps:

--- a/tools/formatter-exportimport/README.md
+++ b/tools/formatter-exportimport/README.md
@@ -1,0 +1,68 @@
+# List formatting export/import 
+The [Export-SPOListFormatting.ps1](tools/formatter-exportimport/Export-SPOListFormatting.ps1) and [Apply-SPOListFormatting.ps1](tools/formatter-exportimport/Apply-SPOListFormatting.ps1) scripts support automated process of exporting existing list customizations and applying them to SPO lists in downstream environments. 
+
+The Export-SPOListFormatting.ps1 allows exporting of SPO list configuration: 
+- form customizers
+- list views
+- list view formatting 
+- columns formatting [Use column formatting to customize SharePoint](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/column-formatting)
+
+## Authentication
+The [Export-SPOListFormatting.ps1](tools/formatter-exportimport/Export-SPOListFormatting.ps1) and [Apply-SPOListFormatting.ps1](tools/formatter-exportimport/Apply-SPOListFormatting.ps1) scripts are using `Connect-PnPOnline` to authenticate to SPO site. 
+
+Both, app registration, and user account are supported. 
+
+## Current limitations
+The script currently only exports settings for Item content type. It can be easily updated to evaluate all existing content types in the list.
+
+
+## List  customizers
+Although the user interface for managing list, column and view formatting is fairly new, the SharePoint capabilities supporting it are not. 
+ 
+Manual steps for **customizing forms** are described in [Show or hide columns in a list or library form](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/list-form-conditional-show-hide) and [Configure the list form](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/list-form-configuration) articles. 
+The form customizations and column order and visibility are defined in `$contentType.ClientFormCustomFormatter` and  `$contentType.FieldLinks`, respectively.
+
+**List view formatting**, described in [Use view formatting to customize SharePoint](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/view-formatting), is defined in `$view.CustomFormatter`. 
+
+**Columns formatting**, described in [Use column formatting to customize SharePoint](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/column-formatting) is defined in... yes, correct ;), `$column.CustomFormatter`
+
+## Azure Pipelines
+To reuse the exported definitions in Azure Pipelines, they are saved in *.json or *.csv formats to the repo. 
+
+### Example export pipeline
+```
+# vmImage: 'ubuntu-latest'
+
+steps:
+- checkout: self
+    persistCredentials: true
+- task: powershell@2
+    name: exportListCustomizers
+    inputs:
+    filePath: $(Build.SourcesDirectory)/Pipelines/scripts/Export-SPOListFormatting.ps1
+    arguments: '-tenantName ''$(Az_TenantName)'' -siteName ''$(SPO_SiteName)'' -userName ''$(SvcAcct-Name)'' -userPassword (ConvertTo-SecureString -AsPlainText $(SvcAcct-Pswd) -Force) -folderPath ''$(Build.SourcesDirectory)/Pipelines/scripts/templates'' '
+    displayName: Export list customizers   
+- script: |
+    git config --global user.email $BUILD_REQUESTEDFOREMAIL
+    git config --global user.name "$BUILD_REQUESTEDFOR"
+    ECHO "CHECK GIT STATUS..."
+    git status
+    git add $(Build.SourcesDirectory)/Pipelines/scripts/templates
+    git commit -m "List customizers exported from (Environment) environment  [skip ci]"
+    git push  origin HEAD:$(Build.SourceBranch)
+    displayName: Commit generated files to repo
+```
+### Example export pipeline
+```
+# vmImage: 'ubuntu-latest'
+steps:
+- checkout: none
+- download: current
+    artifact: drop
+- task: powershell@2
+    name: setSPOListsFormatting
+    inputs:
+    filePath: $(Pipeline.Workspace)/drop/scripts/Apply-SPOListFormatting.ps1
+    arguments: '-tenantName ''$(Az_TenantName)'' -siteName ''$(SPO_SiteName)'' -userName ''$(SPO-SvcAcct-Name)'' -userPassword (ConvertTo-SecureString -AsPlainText $(SPO-SvcAcct-Pswd) -Force) -folderPath ''$(Pipeline.Workspace)/drop/scripts/templates'' '
+    displayName:  Set List Formatting
+```

--- a/tools/formatter-exportimport/README.md
+++ b/tools/formatter-exportimport/README.md
@@ -5,7 +5,7 @@ The Export-SPOListFormatting.ps1 allows exporting of SPO list configuration:
 - form customizers
 - list views
 - list view formatting 
-- columns formatting [Use column formatting to customize SharePoint](https://docs.microsoft.com/en-us/sharepoint/dev/declarative-customization/column-formatting)
+- columns formatting 
 
 ## Authentication
 The [Export-SPOListFormatting.ps1](tools/formatter-exportimport/Export-SPOListFormatting.ps1) and [Apply-SPOListFormatting.ps1](tools/formatter-exportimport/Apply-SPOListFormatting.ps1) scripts are using `Connect-PnPOnline` to authenticate to SPO site. 


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no 
| New sample?      | no 
| Related issues?  | 

#### What's in this Pull Request?
The Export-SPOListFormatting.ps1 and Apply-SPOListFormatting.ps1 scripts support automated process of exporting existing list customizations and applying them to SPO lists in downstream environments.

The Export-SPOListFormatting.ps1 allows exporting of SPO list configuration:
- form customizers
- list views
- list view formatting
- columns formatting
