### PR TITLE
Updating the reference to ImgHover to fix the broken image

### DIFF
--- a/view-samples/announcements/README.md
+++ b/view-samples/announcements/README.md
@@ -29,7 +29,7 @@ announcements.json | [David Ramalho](https://github.com/DRamalho92) ([@davRamalh
 | Version | Date             | Comments        |
 | ------- | ---------------- | --------------- |
 | 1.0     | 1 December, 2021 | Initial release |
-| 1.1     | 17 Septempber, 2023 | The new Image column can now be created, and the use of the Image column is now common when using images. Therefore, changed the type of ImgHover column from Picture column to Image column. |
+| 1.1     | 17 September, 2023 | The new Image column can now be created, and the use of the Image column is now common when using images. Therefore, changed the type of ImgHover column from Picture column to Image column. |
 
 ## Disclaimer
 

--- a/view-samples/announcements/README.md
+++ b/view-samples/announcements/README.md
@@ -16,7 +16,7 @@ This sample formats your view to look like a Announcements card with a similiar 
 | Description         | Single Line Text                       | Description          |
 | TypeAnn             | Choice (Error, Success, Info, Warning) | TypeAnn              |
 | RemoveDate         | Date and Time                          | RemoveDate          |
-| (optional) ImgHover | Picture                                | ImgHover             |
+| (optional) ImgHover | Image                                | ImgHover             |
 
 ## Sample
 
@@ -29,6 +29,7 @@ announcements.json | [David Ramalho](https://github.com/DRamalho92) ([@davRamalh
 | Version | Date             | Comments        |
 | ------- | ---------------- | --------------- |
 | 1.0     | 1 December, 2021 | Initial release |
+| 1.1     | 17 Septempber, 2023 | The new Image column can now be created, and the use of the Image column is now common when using images. Therefore, changed the type of ImgHover column from Picture column to Image column. |
 
 ## Disclaimer
 

--- a/view-samples/announcements/announcements.json
+++ b/view-samples/announcements/announcements.json
@@ -17,7 +17,7 @@
           {
             "elmType": "img",
             "attributes": {
-              "src": "[$ImgHover]"
+              "src": "[$ImgHover.serverRelativeUrl]"
             }
           }
         ],

--- a/view-samples/announcements/assets/sample.json
+++ b/view-samples/announcements/assets/sample.json
@@ -10,7 +10,7 @@
       "This sample formats your view to look like a Announcements card with a similiar style to Viva Connection Cards when on a SharePoint Page. In Microsoft Lists it will also show an image that you can connect with the Announcement."
     ],
     "creationDateTime": "2021-12-01T00:00:00.000Z",
-    "updateDateTime": "2021-12-01T00:00:00.000Z",
+    "updateDateTime": "2023-09-17T00:00:00.000Z",
     "products": [
       "SharePoint",
       "Microsoft Lists"


### PR DESCRIPTION
ImgHover represents an object, not a string. Adding ".serverRelativeUrl" will properly reference the image URL, fixing the issue.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New sample?      | no
| Related issues?  | no (unreported)

#### What's in this Pull Request?
A tweak to the ImgHover field reference. The JSON currently doesn't display the image as suggested by the screenshot. This tweak properly references the ImgHover field as an object, and uses the serverRelativeUrl property to get the image URL.
