### PR TITLE
Updated samples to use getThumbnailImage after serverRelativeURL stop…

### DIFF
--- a/column-samples/image-lightbox/README.md
+++ b/column-samples/image-lightbox/README.md
@@ -11,8 +11,6 @@ An additional format (image-lightbox-advanced.json) is provided which demonstrat
 
 ![screenshot of the advanced sample](./assets/screenshotAdvanced.gif)
 
-Additional details about what size options are available can be found here: [Drive Item Thumbnail Size Options](https://docs.microsoft.com/graph/api/driveitem-list-thumbnails?view=graph-rest-1.0&tabs=http#size-options)
-
 ## View requirements
 - This format can be applied to any image column type (Note: this sample does not work with the Picture column type)
 
@@ -30,7 +28,7 @@ Version|Date|Comments
 -------|----|--------
 1.0|February 10, 2020|Initial release
 1.1|July 8, 2021|Added advanced format
-
+1.2|October 26, 2023|Updated samples to use getThumbnailImage
 
 ## Disclaimer
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**

--- a/column-samples/image-lightbox/assets/sample.json
+++ b/column-samples/image-lightbox/assets/sample.json
@@ -10,7 +10,7 @@
       "This sample demonstrates showing the full size image in a lightbox (hover card) rather than opening this image in a new window."
     ],
     "creationDateTime": "2020-02-10T00:00:00.000Z",
-    "updateDateTime": "2021-07-08T00:00:00.000Z",
+    "updateDateTime": "2023-10-26T00:00:00.000Z",
     "products": [
       "SharePoint",
       "Microsoft Lists"
@@ -38,7 +38,7 @@
       },
       {
         "key": "FORMATTING-OPERATORS",
-        "value": "ceiling"
+        "value": "ceiling, getThumbnailImage"
       },
       {
         "key": "FORMATTING-ACTIONS",

--- a/column-samples/image-lightbox/image-lightbox-advanced.json
+++ b/column-samples/image-lightbox/image-lightbox-advanced.json
@@ -16,7 +16,7 @@
     {
       "elmType": "img",
       "attributes": {
-        "src": "=@currentField.thumbnailRenderer.spItemUrl + '/thumbnails/0/c48x48/content?prefer=noredirect%2Cclosestavailablesize&cb=1&s=' + @currentField.thumbnailRenderer.sponsorToken"
+        "src": "=getThumbnailImage(@currentField, 64, 64)"
       },
       "customCardProps": {
         "formatter": {
@@ -29,7 +29,7 @@
             {
               "elmType": "img",
               "attributes": {
-                "src": "=@currentField.thumbnailRenderer.spItemUrl + '/thumbnails/0/c' + ceiling(@window.innerWidth*.5) + 'x' + ceiling(@window.innerHeight*.5) + '/content?prefer=noredirect&cb=1&s=' + @currentField.thumbnailRenderer.sponsorToken",
+                "src": "=getThumbnailImage(@currentField, ceiling(@window.innerWidth*.5), ceiling(@window.innerHeight*.5))",
                 "title": "@currentField.fileName"
               },
               "style": {
@@ -40,7 +40,7 @@
               "elmType": "a",
               "attributes": {
                 "iconName": "OpenInNewWindow",
-                "href": "=@currentField.thumbnailRenderer.spItemUrl + '/thumbnails/0/c3000x2000/content?prefer=noredirect&cb=1&s=' + @currentField.thumbnailRenderer.sponsorToken",
+                "href": "=getThumbnailImage(@currentField, 3000, 2000)",
                 "target": "_blank",
                 "class": "ms-bgColor-black ms-fontColor-white ms-fontColor-themeLight--hover",
                 "title": "Open in New Window"

--- a/column-samples/image-lightbox/image-lightbox.json
+++ b/column-samples/image-lightbox/image-lightbox.json
@@ -16,20 +16,20 @@
     {
       "elmType": "img",
       "attributes": {
-        "src": "=@currentField.thumbnailRenderer.spItemUrl + '/thumbnails/0/c48x48/content?prefer=noredirect%2Cclosestavailablesize&cb=1&s=' + @currentField.thumbnailRenderer.sponsorToken"
+        "src": "=getThumbnailImage(@currentField, 64, 64)"
       },
       "customCardProps": {
         "formatter": {
           "elmType": "div",
           "style": {
             "padding": "8px",
-            "background-color": "black"
+            "background-color": "white"
           },
           "children": [
             {
               "elmType": "img",
               "attributes": {
-                "src": "=@currentField.thumbnailRenderer.spItemUrl + '/thumbnails/0/c3000x2000/content?prefer=noredirect%2Cclosestavailablesize&cb=1&s=' + @currentField.thumbnailRenderer.sponsorToken",
+                "src": "=getThumbnailImage(@currentField, 500, 500)",
                 "title": "@currentField.fileName"
               },
               "style": {
@@ -42,7 +42,7 @@
         "directionalHint": "rightCenter",
         "isBeakVisible": true,
         "beakStyle": {
-          "backgroundColor": "black"
+          "backgroundColor": "white"
         }
       }
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        |  yes


#### What's in this Pull Request?

The image column no longer returns the **serverRelativeURL** for new images added to the list. While this works fine for images uploaded before this change it no longer works for new ones. This PR replaces the URLs used to make the image preview by the **getThumbnailImage** function. This change make the sample work for both new and old images

