### PR TITLE
Fixed a issue that images could not be downloaded

### DIFF
--- a/column-samples/generic-image-download/README.md
+++ b/column-samples/generic-image-download/README.md
@@ -6,9 +6,8 @@ This sample demonstrates adding a button within a SharePoint Online/Microsoft Li
 
 ![screenshot of the sample output](./assets/screenshot.png)
 
-## List requirements
-
-Attachments need to be disabled on the list in order for the solution to work.
+## JSON note
+For this JSON to work in your list, make sure to edit the JSON and replace the **YOUR-LIST-NAME** placeholder with your list's name, as it appears in the URL (including special characters)
 
 ## View requirements
 

--- a/column-samples/generic-image-download/README.md
+++ b/column-samples/generic-image-download/README.md
@@ -7,7 +7,7 @@ This sample demonstrates adding a button within a SharePoint Online/Microsoft Li
 ![screenshot of the sample output](./assets/screenshot.png)
 
 ## JSON note
-For this JSON to work in your list, make sure to edit the JSON and replace the **YOUR-LIST-NAME** placeholder with your list's name, as it appears in the URL (including special characters)
+For this JSON to work in your list, make sure to edit the JSON and replace the `**YOUR-LIST-NAME**` placeholder with your list's name, as it appears in the URL (including special characters)
 
 ## View requirements
 
@@ -28,6 +28,7 @@ generic-image-download.json | [Ganesh Sanap](https://github.com/ganesh-sanap) ([
 Version |Date          |Comments
 --------|--------------|--------------------------------
 1.0     |November 12, 2022 |Initial release
+1.1     |January 16, 2024 |Fixed an issue where images could not be downloaded due to a change in image storage location
 
 ## Disclaimer
 

--- a/column-samples/generic-image-download/README.md
+++ b/column-samples/generic-image-download/README.md
@@ -6,6 +6,10 @@ This sample demonstrates adding a button within a SharePoint Online/Microsoft Li
 
 ![screenshot of the sample output](./assets/screenshot.png)
 
+## List requirements
+
+Attachments need to be disabled on the list in order for the solution to work.
+
 ## View requirements
 
 This format can be applied to any column type (its value is ignored). However, it is expected that the following one column is part of the view.

--- a/column-samples/generic-image-download/assets/sample.json
+++ b/column-samples/generic-image-download/assets/sample.json
@@ -10,7 +10,7 @@
       "This sample demonstrates adding a button within a SharePoint Online/Microsoft Lists view which downloads the image from image column."
     ],
     "creationDateTime": "2022-11-12T00:00:00.000Z",
-    "updateDateTime": "2022-11-12T00:00:00.000Z",
+    "updateDateTime": "2024-01-16T00:00:00.000Z",
     "products": [
       "SharePoint",
       "Microsoft Lists"

--- a/column-samples/generic-image-download/generic-image-download.json
+++ b/column-samples/generic-image-download/generic-image-download.json
@@ -20,7 +20,7 @@
         "width": "100%"
       },
       "attributes": {
-        "href": "= @currentWeb + '/_layouts/15/download.aspx?sourceurl=' + [$Image.serverRelativeUrl]",
+        "href": "=@currentWeb+'/_layouts/15/download.aspx?sourceurl='+if([$Image.serverRelativeUrl],[$Image.serverRelativeUrl],@currentWeb+'/Lists/**YOUR-LIST-NAME**/Attachments/'+[$ID]+'/'+[$Image.fileName])",
         "target": "_blank",
         "class": "ms-fontColor-white ms-fontSize-m"
       },


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New sample?      | no
| Related issues?  | no

#### What's in this Pull Request?
Updating the Readme file. In order for the download URL to be complete, attachments need to be disabled on the list. Otherwise, the serverRelativeURL in the expression resolves to a blank string. This PR just adds that note to the Readme.
