### PR TITLE
Fixed problem with date not displaying

### DIFF
--- a/form-samples/workflow-progress-header/README.md
+++ b/form-samples/workflow-progress-header/README.md
@@ -24,6 +24,7 @@ workflow-progress-header.json | [Tetsuya Kawahara](https://github.com/tecchan110
 Version |Date             |Comments
 --------|-----------------|--------
 1.0     |February 1, 2021 |Initial release
+1.1     |April 19, 2024 |Fixed to use `[$ColumnName.displayValue]` instead of `toLocaleDateString` operator to solve the problem that date is not displayed depending on the date format.
 
 
 ## Disclaimer

--- a/form-samples/workflow-progress-header/assets/sample.json
+++ b/form-samples/workflow-progress-header/assets/sample.json
@@ -10,7 +10,7 @@
       "This sample shows a checkmark for each date field that has a value to help convey when milestones have been hit."
     ],
     "creationDateTime": "2021-02-01T00:00:00.000Z",
-    "updateDateTime": "2021-02-01T00:00:00.000Z",
+    "updateDateTime": "2024-04-19T00:00:00.000Z",
     "products": [
       "SharePoint",
       "Microsoft Lists"
@@ -38,7 +38,7 @@
       },
       {
         "key": "FORMATTING-OPERATORS",
-        "value": "Number, toLocaleDateString"
+        "value": "Number"
       },
       {
         "key": "FORMATTING-ACTIONS",

--- a/form-samples/workflow-progress-header/workflow-progress-header.json
+++ b/form-samples/workflow-progress-header/workflow-progress-header.json
@@ -40,7 +40,7 @@
         },
         {
           "elmType": "div",
-          "txtContent": "=toLocaleDateString([$Date1])"
+          "txtContent": "=[$Date1.displayValue]"
         }
       ]
     },
@@ -73,7 +73,7 @@
         },
         {
           "elmType": "div",
-          "txtContent": "=toLocaleDateString([$Date2])"
+          "txtContent": "=[$Date2.displayValue]"
         }
       ]
     },
@@ -106,7 +106,7 @@
         },
         {
           "elmType": "div",
-          "txtContent": "=toLocaleDateString([$Date3])"
+          "txtContent": "=[$Date3.displayValue]"
         }
       ]
     }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New sample?      | 
| Related issues?  | 

#### What's in this Pull Request?

Received feedback that the `dd/MM/yyyy` format does not display dates. To resolve this, we used `[$ColumnName.displayValue]` instead of the `toLocaleDateString` operator, and the problem was completed.