### PR TITLE
Update README.md

### DIFF
--- a/column-samples/approval-buttons-setValue-status-user/README.md
+++ b/column-samples/approval-buttons-setValue-status-user/README.md
@@ -14,10 +14,11 @@ Key points:
 
 |Type|Internal Name|Required|Additional Information
 |---|---|:---:|---|
-|Single Line of Text|Approval|Yes| Apply [approval-buttons-setValue-status-user.json](./approval-buttons-setValue-status-user.json) to this column
+|Any (see below)|Approval|Yes| Apply [approval-buttons-setValue-status-user.json](./approval-buttons-setValue-status-user.json) to this column
 |Choice|ItemStatus|No| Choice values needed: (Pending / Approved / Rejected) Default: Pending
 |Person or Group|ApprovalActionBy|No|Single selection
 
+- The format can be applied to any column, although it is recommended to add it to a calculated column with a ="" formula
 
 ## Sample
 

--- a/column-samples/approval-buttons-setValue-status-user/README.md
+++ b/column-samples/approval-buttons-setValue-status-user/README.md
@@ -18,7 +18,7 @@ Key points:
 |Choice|ItemStatus|No| Choice values needed: (Pending / Approved / Rejected) Default: Pending
 |Person or Group|ApprovalActionBy|No|Single selection
 
-- The format can be applied to any column, although it is recommended to add it to a calculated column with a ="" formula
+- The format can be applied to any column, although it is recommended to add it to a calculated column with a `=""` formula
 
 ## Sample
 

--- a/column-samples/approval-buttons-setValue-status-user/README.md
+++ b/column-samples/approval-buttons-setValue-status-user/README.md
@@ -14,7 +14,7 @@ Key points:
 
 |Type|Internal Name|Required|Additional Information
 |---|---|:---:|---|
-|Calculated|Approval|Yes| Apply [approval-buttons-setValue-status-user.json](./approval-buttons-setValue-status-user.json) to this column
+|Single Line of Text|Approval|Yes| Apply [approval-buttons-setValue-status-user.json](./approval-buttons-setValue-status-user.json) to this column
 |Choice|ItemStatus|No| Choice values needed: (Pending / Approved / Rejected) Default: Pending
 |Person or Group|ApprovalActionBy|No|Single selection
 


### PR DESCRIPTION
The Approval field indicates that it's a calculated column, but no formula is required. This solution appears to work fine with that column as a single line of text column.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New sample?      | no
| Related issues?  | no

#### What's in this Pull Request?

The README lists the Approval column as a calculated column. That column type requires a formula to create, and no formula was provided. Because a JSON formatter is used here, the formula is unnecessary anyway, and can be swapped for a single line of text column, correcting the column creation process.