### PR TITLE
Changed to use `getUserImage` operator

### DIFF
--- a/view-samples/group-header-user-picture/README.md
+++ b/view-samples/group-header-user-picture/README.md
@@ -22,6 +22,7 @@ group-header-user-picture.json | [Tetsuya Kawahara](https://github.com/tecchan11
 Version |Date          |Comments
 --------|--------------|--------------------------------
 1.0     |April 3, 2021 |Initial release
+1.1     |October 16, 2024 |Changed to use `getUserImage` operator to get user's picture
 
 ## Disclaimer
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**

--- a/view-samples/group-header-user-picture/assets/sample.json
+++ b/view-samples/group-header-user-picture/assets/sample.json
@@ -10,7 +10,7 @@
       "This is a sample of customizing the group header when grouping by user column. Display the user's picture as well as the user's name in the group header."
     ],
     "creationDateTime": "2021-04-03T00:00:00.000Z",
-    "updateDateTime": "2021-04-03T00:00:00.000Z",
+    "updateDateTime": "2024-10-16T00:00:00.000Z",
     "products": [
       "SharePoint",
       "Microsoft Lists"
@@ -38,7 +38,7 @@
       },
       {
         "key": "FORMATTING-OPERATORS",
-        "value": ""
+        "value": "getUserImage"
       },
       {
         "key": "FORMATTING-ACTIONS",

--- a/view-samples/group-header-user-picture/group-header-user-picture.json
+++ b/view-samples/group-header-user-picture/group-header-user-picture.json
@@ -36,7 +36,7 @@
             {
               "elmType": "img",
               "attributes": {
-                "src": "=@currentWeb + '/_layouts/15/userphoto.aspx?size=S&accountname=' + @group.fieldData.email",
+                "src": "=getUserImage(@group.fieldData.email,'s')",
                 "title": "@group.fieldData.title"
               },
               "style": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no 
| New sample?      | no 
| Related issues?  | 

#### What's in this Pull Request?

After this sample was published, a new dedicated operator was added to retrieve the user's picture. Change to use that operator.