### PR TITLE
Fix misalignment caused by latest updates

### DIFF
--- a/view-samples/annual-performance-review/README.md
+++ b/view-samples/annual-performance-review/README.md
@@ -44,7 +44,7 @@ Version|Date|Comments
 1.0    |October 6, 2024|Initial release
 2.0    |October 16, 2024|New layout
 2.1    |October 24, 2024|Added edit mode switch, fixed border thickness and alignment.
-2.2    |October 27, 2024|Corrected the misalignment issues caused by the recent updates.
+2.2    |October 30, 2024|Corrected the misalignment issues caused by the recent updates.
 
 ## Disclaimer
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**

--- a/view-samples/annual-performance-review/README.md
+++ b/view-samples/annual-performance-review/README.md
@@ -15,7 +15,7 @@ This diagram represents the structure of how the list view is formatted. It show
 
 ## View requirements
 
-- Group by Employee field in the view settings.
+- Group by Employee field in the view settings and set default to Expanded to show user's photo in group header.
 - This format expects the following columns to be part of the view:
 
 Column Name | Required | Type
@@ -44,6 +44,7 @@ Version|Date|Comments
 1.0    |October 6, 2024|Initial release
 2.0    |October 16, 2024|New layout
 2.1    |October 24, 2024|Added edit mode switch, fixed border thickness and alignment.
+2.2    |October 27, 2024|Corrected the misalignment issues caused by the recent updates.
 
 ## Disclaimer
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**

--- a/view-samples/annual-performance-review/annual-performance-review.json
+++ b/view-samples/annual-performance-review/annual-performance-review.json
@@ -96,10 +96,10 @@
     "elmType": "div",
     "style": {
       "display": "block",
-      "background-color": "#e9f7f7",
+      "background-color": "#E9F7F7",
       "width": "=(700-10*2)+'px'",
       "padding": "10px",
-      "margin": "6px 0 20px 80px",
+      "margin": "2px 0 14px 44px",
       "border": "2px solid #e5e5e5",
       "border-radius": "8px"
     },
@@ -159,7 +159,7 @@
                           "width": "=(Number([$Q1e])+Number([$Q2e])+Number([$Q3e])+Number([$Q4e]))/12*100+'%'",
                           "max-width": "100%",
                           "height": "100%",
-                          "background-color": "#4caf50",
+                          "background-color": "#4CAF50",
                           "border-radius": "5px"
                         }
                       }
@@ -197,7 +197,7 @@
                           "width": "=(Number([$Q1m])+Number([$Q2m])+Number([$Q3m])+Number([$Q4m]))/12*100+'%'",
                           "max-width": "100%",
                           "height": "100%",
-                          "background-color": "#4caf50",
+                          "background-color": "#4CAF50",
                           "border-radius": "5px"
                         }
                       }
@@ -274,7 +274,6 @@
                         "style": {
                           "width": "50%",
                           "text-align": "center",
-                          "xpadding": "5px 0px",
                           "cursor": "pointer",
                           "background-color": "=if([$EditMode],'#696CB3','transparent')",
                           "color": "=if([$EditMode],'white','black')",

--- a/view-samples/annual-performance-review/assets/sample.json
+++ b/view-samples/annual-performance-review/assets/sample.json
@@ -10,7 +10,7 @@
       "This sample demonstrates how to change row data to column format for annual performance review form."
     ],
     "creationDateTime": "2024-10-06T00:00:00.000Z",
-    "updateDateTime": "2024-10-24T00:00:00.000Z",
+    "updateDateTime": "2024-10-30T00:00:00.000Z",
     "products": [
       "SharePoint",
       "Microsoft Lists"


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New sample?      | no
| Related issues?  | 

#### What's in this Pull Request?

1. Corrected the misalignment issues caused by this week's updates "hideSelection": true
Previously, it only hid items, now it also hides group header selection.
2. Minor changes.
3. Added setting to default Exapanded to show user's photo in README.
After conducting additional testing, I observed that @group.fieldData.email only functioned properly when I set the default to "Expanded" within the Group settings.

Feel free to make any changes as you see fit.
<img width="565" alt="image" src="https://github.com/user-attachments/assets/2a424833-ebab-4411-8b8c-9dbc2763c0c0">
