### PR TITLE
Fixed the layout to make the hidden text visible. Fix #897

### DIFF
--- a/column-samples/date-page-a-day-calendar/README.md
+++ b/column-samples/date-page-a-day-calendar/README.md
@@ -23,6 +23,7 @@ Version |Date             |Comments
 1.1     |August  2, 2021  |Fixed to show days of the week.
 1.2     |October 2, 2022  |Fixed incorrect days of the week being displayed.
 1.3     |December 13, 2024|Added `date-page-a-day-calendar-rounded.json`
+1.4     |December 14, 2024|Adjusted the layout for `date-page-a-day-calendar.json` to ensure that the day-of-the-week text, which was partially hidden due to the update, is now visible. 
 
 ## Disclaimer
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**

--- a/column-samples/date-page-a-day-calendar/assets/sample.json
+++ b/column-samples/date-page-a-day-calendar/assets/sample.json
@@ -10,7 +10,7 @@
       "This sample customizes a date column to look like a page-a-day calendar. It does this by using the date part functions (\u0060getDate\u0060, \u0060getMonth\u0060, and \u0060getYear\u0060)."
     ],
     "creationDateTime": "2020-10-17T00:00:00.000Z",
-    "updateDateTime": "2022-10-02T00:00:00.000Z",
+    "updateDateTime": "2024-12-14T00:00:00.000Z",
     "products": [
       "SharePoint",
       "Microsoft Lists"

--- a/column-samples/date-page-a-day-calendar/date-page-a-day-calendar.json
+++ b/column-samples/date-page-a-day-calendar/date-page-a-day-calendar.json
@@ -4,7 +4,7 @@
   "style": {
     "flex-direction": "column",
     "width": "50px",
-    "margin": "5px",
+    "margin": "5px 10px",
     "display": "=if(@currentField,'flex','none')"
   },
   "children": [


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New sample?      | no
| Related issues?  | fixes #897

#### What's in this Pull Request?

Adjusted the layout for `date-page-a-day-calendar.json` to ensure that the day-of-the-week text, which was partially hidden due to the update, is now visible. 