### PR TITLE
Update commandbar-hide-all.json

### DIFF
--- a/view-samples/commandbar-hide-all/README.md
+++ b/view-samples/commandbar-hide-all/README.md
@@ -25,6 +25,7 @@ Version|Date|Comments
 -------|----|--------
 1.0|December 24, 2024|Initial release
 1.1|May 3, 2025|Added/updated command bar props/images
+1.2|June 28, 2025|Added `PublishCommand`, `properties`
 
 ## Disclaimer
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**

--- a/view-samples/commandbar-hide-all/assets/sample.json
+++ b/view-samples/commandbar-hide-all/assets/sample.json
@@ -10,7 +10,7 @@
       "This sample demonstrates hiding all buttons on the command bar."
     ],
     "creationDateTime": "2024-12-24T00:00:00.000Z",
-    "updateDateTime": "2025-05-03T00:00:00.000Z",
+    "updateDateTime": "2025-06-28T00:00:00.000Z",
     "products": [
       "SharePoint",
       "Microsoft Lists"

--- a/view-samples/commandbar-hide-all/commandbar-hide-all.json
+++ b/view-samples/commandbar-hide-all/commandbar-hide-all.json
@@ -78,7 +78,9 @@
       { "key": "stasherContextMenuCommand", "hide": true },
       { "key": "syntexTranslateCommand", "hide": true },
       { "key": "requestApprovalCommand", "hide": true },
-      { "key": "GoToChannelInTeams", "hide": true }
+      { "key": "GoToChannelInTeams", "hide": true },
+      { "key": "PublishCommand", "hide": true},
+      { "key": "properties", "hide": true}
     ]
   }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New sample?      | no
| Related issues?  | fixes

Added two more command buttons, "PublishCommand" and "properties" that were not previously hidden (these two commands are only visible upon selecting a file).