### PR TITLE
Update JSON to increase the width of the Answer column

### DIFF
--- a/view-samples/faq-grouped/README.md
+++ b/view-samples/faq-grouped/README.md
@@ -5,6 +5,9 @@ This sample uses standard group rendering to provide a list of expandable questi
 
 ![screenshot of the sample](./assets/screenshot.png)
 
+This sample includes two variations: the original `faq-grouped.json` and `faq-grouped-full-width-answer.json`.
+- **faq-grouped.json** – Applies formatting only to the group header. The width of the answer depends on the column width.
+- **faq-grouped-full-width-answer.json** – Also includes a `rowFormatter` to style the entire row, allowing the answer to span the full width of the page. However, only the `Answer` column is shown; other columns are not displayed.
 
 ## View requirements
 
@@ -22,12 +25,14 @@ In this case, the Title column has been renamed to Question (though it doesn't m
 Solution|Author(s)
 --------|---------
 faq-grouped.json | [Chris Kent](https://github.com/thechriskent) ([@thechriskent](https://twitter.com/thechriskent))
+faq-grouped-full-width-answer.json | [Steve Corey](https://github.com/stevecorey365)
 
 ## Version history
 
 Version|Date|Comments
 -------|----|--------
 1.0|April 15, 2022|Initial release
+1.1|August 11, 2025|Added `faq-grouped-full-width-answer.json`
 
 ## Disclaimer
 **THIS CODE IS PROVIDED *AS IS* WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING ANY IMPLIED WARRANTIES OF FITNESS FOR A PARTICULAR PURPOSE, MERCHANTABILITY, OR NON-INFRINGEMENT.**

--- a/view-samples/faq-grouped/assets/sample.json
+++ b/view-samples/faq-grouped/assets/sample.json
@@ -10,7 +10,7 @@
       "This sample uses standard group rendering to provide a list of expandable questions. By default, when grouping by a column the column name and the count of grouped items will be included in the group name. This format provides some small tweaks to the group header to only show the value (question in this case). By also hiding the column header and item selection, this format acts like a mini application and could easily be added to a page using the list web part."
     ],
     "creationDateTime": "2022-04-15T00:00:00.000Z",
-    "updateDateTime": "2020-04-15T00:00:00.000Z",
+    "updateDateTime": "2025-08-11T00:00:00.000Z",
     "products": [
       "SharePoint",
       "Microsoft Lists"
@@ -66,6 +66,11 @@
         "gitHubAccount": "thechriskent",
         "pictureUrl": "https://github.com/thechriskent.png",
         "name": "Chris Kent"
+      },
+      {
+        "gitHubAccount": "stevecorey365",
+        "pictureUrl": "https://github.com/stevecorey365.png",
+        "name": "Steve Corey"
       }
     ],
     "references": [

--- a/view-samples/faq-grouped/faq-grouped-full-width-answer.json
+++ b/view-samples/faq-grouped/faq-grouped-full-width-answer.json
@@ -1,0 +1,27 @@
+{
+  "$schema": "https://developer.microsoft.com/json-schemas/sp/v2/row-formatting.schema.json",
+  "hideColumnHeader": true,
+  "hideSelection": true,
+  "groupProps": {
+    "headerFormatter": {
+      "elmType": "div",
+      "txtContent": "@group.fieldData",
+      "attributes": {
+        "class": "sp-row-title ms-fontSize-xl"
+      }
+    }
+  },
+  "additionalRowClass": "ms-font-l ms-fontColor-neutralPrimary ms-bgColor-white--hover",
+  "rowFormatter": {
+    "elmType": "div",
+    "children": [
+      {
+        "elmType": "div",
+        "style": {
+          "margin": "10px 30px"
+        },
+        "txtContent": "[$Answer]"
+      }
+    ]
+  }
+}

--- a/view-samples/faq-grouped/faq-grouped.json
+++ b/view-samples/faq-grouped/faq-grouped.json
@@ -11,22 +11,5 @@
       }
     }
   },
-  "additionalRowClass": "ms-font-l ms-fontColor-neutralPrimary ms-bgColor-white--hover",
-  "rowFormatter": {
-    "elmType": "div",
-    "style": {
-      "display": "flex",
-      "flexDirection": "column",
-      "width": "100%"
-    },
-    "children": [
-      {
-        "elmType": "div",
-        "style": {
-          "width": "100%"
-        },
-        "txtContent": "[$Answer]"
-      }
-    ]
-  }
+  "additionalRowClass": "ms-font-l ms-fontColor-neutralPrimary ms-bgColor-white--hover"
 }

--- a/view-samples/faq-grouped/faq-grouped.json
+++ b/view-samples/faq-grouped/faq-grouped.json
@@ -11,5 +11,22 @@
       }
     }
   },
-  "additionalRowClass": "ms-font-l ms-fontColor-neutralPrimary ms-bgColor-white--hover"
+  "additionalRowClass": "ms-font-l ms-fontColor-neutralPrimary ms-bgColor-white--hover",
+  "rowFormatter": {
+    "elmType": "div",
+    "style": {
+      "display": "flex",
+      "flexDirection": "column",
+      "width": "100%"
+    },
+    "children": [
+      {
+        "elmType": "div",
+        "style": {
+          "width": "100%"
+        },
+        "txtContent": "[$Answer]"
+      }
+    ]
+  }
 }


### PR DESCRIPTION
The answer column is narrow by default. This additional rowformatter element fixes that.

| Q               | A
| --------------- | ---
| Bug fix?        | yes
| New sample?      | no

#### What's in this Pull Request?
By default, the Answer column is displayed with a narrow width, This update fixes that and forces Answer to be 100% width.
